### PR TITLE
Godfather's child I/Os that wants to reexectue may can't done and los…

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3408,7 +3408,7 @@ zio_done(zio_t *zio)
 	         * If Godfather there were child I/Os that wants to reexecute,
 	         * we only clear the suspend flag bit, so that the Godfather can
 	         * keep on monitor its children which need to reexecute now. Otherwise
-	         * the Godfather I/O ignore this and done, it will cause those child I/Os
+	         * the Godfather I/O ignore this and done, it will lead to child I/Os
 	         * lost monitor I/O and have no chance to reexecute again.
 	         */
 	    	if ((zio->io_child_count > 0) &&


### PR DESCRIPTION
Dear All,
When testing ZFS on Linux I ran into a problem with ZIO pipeline execute exception. 
when accessing the ZFS filesystem via NFS(v3/v4), while disconnect and connect 
the disk at the same time, occured zio can't done and lost chance to reexecute again. 
Furthermore the spa sync thread will suspend due to wait orphans zio to execute done.

I thank that the problem has a relationship with the following code in function `zio_done`, 
and detail description as follows:

```
/*
 * Godfather I/Os should never suspend.
 */
if ((zio->io_flags & ZIO_FLAG_GODFATHER) &&
    (zio->io_reexecute & ZIO_REEXECUTE_SUSPEND))
    zio->io_reexecute = 0;
```

In this code, when godfather I/O's io_reexecute flag contain ZIO_REEXECUTE_SUSPEND bit, 
its io_reexecute flag will reset, and then execute done and destroy.
In my test, the godfather I/O only indicate spa_suspend_zio_root, when i testing the godfather I/O
have two or more children, and then resume it via zpool clear, so the zio_reexecute function will recursive reexecute all previously suspended i/o.

After resume the godfather I/O , some child zio's io_reexecute flag assigned ZIO_REEXECUTE_NOW bit, but others assigned ZIO_REEXECUTE_SUSPEND bit,so the godfather I/O's io_reexecute flag will inherit both ZIO_REEXECUTE_NOW and ZIO_REEXECUTE_SUSPEND bit.

However these child I/Os which io_reexecute flag assigned ZIO_REEXECUTE_SUSPEND will remove from current godfater I/O's child list and add to new spa_suspend_zio_root's child list, but others zio which io_reexecute flag assigned ZIO_REEXECUTE_NOW only notify godfater zio to execute and assigned self io_reexecute flag value to godfater zio.

At last, the godfater I/O execute above code in zio_done function, and then godfather I/O execute done and destroy, and this lead to these child zio which io_reexecute flag assigned ZIO_REEXECUTE_NOW will lose monitor zio and have no chance to reexecute again. 
Thanks!
